### PR TITLE
vince: Do not use timeservice_app_cert-legacy-um certificate for Time…

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -217,7 +217,7 @@ android_app_import {
 	name: "TimeService",
 	owner: "xiaomi",
 	apk: "proprietary/vendor/app/TimeService/TimeService.apk",
-	certificate: ":timeservice_app_cert-legacy-um",
+	certificate: "platform",
 	dex_preopt: {
 		enabled: false,
 	},


### PR DESCRIPTION
…Service app

* This cert is no longer present in qcom sepolicy.

Change-Id: Ie4e882058825287d9db3f7a3bdd37c641c67a5c2
Signed-off-by: starlight5234 <starlight5234@protonmail.ch>